### PR TITLE
Align book id usage with ReadMe

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,14 +63,12 @@ async function downloadAndDecryptFile(url) {
     } else {
         console.log("Book list:");
         let i=0;
-        books.forEach((b) => {
-            console.log(`${i++} ${b.title}`);
-        });
-        
+        console.table(books.map(book => ({ id: book.id, title: book.title })))
     }
+    
     let bookId = prompt(`Please input book id${(books.length == 0 ? " manually" : "")}:`);
 
-    let book = await fetch(`https://www.bsmart.it/api/v6/books/by_book_id/${books[bookId].id}`, {headers});
+    let book = await fetch(`https://www.bsmart.it/api/v6/books/by_book_id/${bookId}`, {headers});
 
     if (book.status != 200) {
         console.log("Invalid book id");


### PR DESCRIPTION
Hi @Leone25, first of all, thank you for this awesome project!

Currently, the readme is not aligned with the usage, since the readme instructs to insert the book id from bSmart, but the value needed for the flow to work is the index of the book from the book list. I figured it out by reading the code.

Actually using the original book id makes more sense in my opinion as it was in the first place, so I have changed the code to expect the bSmart book id instead of the index.

I have also made the book list display more friendly using a table:
<img width="381" alt="image" src="https://github.com/Leone25/bSmart-downloader/assets/44297242/62f79bf0-47a4-4883-87d2-b8fee339b307">
